### PR TITLE
 #1 : use BUILD_SYSTEM_HOME variable instead HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ release --branch release/Version-4.37 --comment stable --noscp
 ```
 
 To make minor adjustments to the build, such as the target SDK, target qt version or such, you'd modify the `build-system-intel/variables/darwin-intel`.
+
+By default the scripts assume that the build system is in the HOME directory, if that is not the case, define a variable with the full path to the folder containing the build system directory. By default:
+
+    `BUILD_SYSTEM_HOME=$HOME`
+

--- a/bin/.build
+++ b/bin/.build
@@ -17,6 +17,7 @@ export COPASI_UPLOAD="deploy:build-system/upload/stage"
 # Defaults:
 clean=false
 local=false
+skip_git=false
 comment=
 branch=
 tag=
@@ -31,6 +32,10 @@ while [ _"$1" != _ ]; do
 
   --local)
     local=true
+    ;;
+
+  --nogit)
+    skip_git=true
     ;;
 
   --noscp)
@@ -77,6 +82,8 @@ fi
 # Update the sources
 pushd "${COPASI_SOURCES}"
 
+if [ "${skip_git}" == false ]; then
+
 git fetch --all
 
 if [ "${local}" == false ]; then
@@ -91,6 +98,9 @@ gitTools/initTools
 
 # Determine the COPASI version
 gitTools/UpdateCopasiVersion --force
+
+fi
+
 
 # Set the version comment
 sed -e 's/COPASI_VERSION_COMMENT.*/COPASI_VERSION_COMMENT "'${comment}'"/' \

--- a/profile/darwin
+++ b/profile/darwin
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
 export COPASI_PACKAGE=Darwin
-export VARIABLES="$HOME/build-system/variables/darwin"
+export VARIABLES="$BUILD_SYSTEM_HOME/build-system/variables/darwin"
 export COPASI_READLINK=greadlink
-export PATH="$HOME/build-system/bin:$PATH"
+export PATH="$BUILD_SYSTEM_HOME/build-system/bin:$PATH"
 PS1="[\\u@${COPASI_PACKAGE} \\W]\\\$ "

--- a/profile/darwin-arm
+++ b/profile/darwin-arm
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
 export COPASI_PACKAGE=Darwin-arm
-export VARIABLES="$HOME/build-system-arm/variables/darwin-arm"
+export VARIABLES="$BUILD_SYSTEM_HOME/build-system-arm/variables/darwin-arm"
 export COPASI_READLINK=greadlink
-export PATH="$HOME/build-system-arm/bin:$PATH"
+export PATH="$BUILD_SYSTEM_HOME/build-system-arm/bin:$PATH"
 PS1="[\\u@${COPASI_PACKAGE} \\W]\\\$ "

--- a/profile/darwin-arm
+++ b/profile/darwin-arm
@@ -8,4 +8,9 @@ export COPASI_PACKAGE=Darwin-arm
 export VARIABLES="$BUILD_SYSTEM_HOME/build-system-arm/variables/darwin-arm"
 export COPASI_READLINK=greadlink
 export PATH="$BUILD_SYSTEM_HOME/build-system-arm/bin:$PATH"
+
+if [ -n "$ZSH_VERSION" ]; then
+PS1="[%n@${COPASI_PACKAGE} %~] $ "
+else
 PS1="[\\u@${COPASI_PACKAGE} \\W]\\\$ "
+fi

--- a/profile/darwin-intel
+++ b/profile/darwin-intel
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
+
 export COPASI_PACKAGE=Darwin-intel
-export VARIABLES="$HOME/build-system-intel/variables/darwin-intel"
+export VARIABLES="$BUILD_SYSTEM_HOME/build-system-intel/variables/darwin-intel"
 export COPASI_READLINK=greadlink
-export PATH="$HOME/build-system-intel/bin:$PATH"
+export PATH="$BUILD_SYSTEM_HOME/build-system-intel/bin:$PATH"
 
 export QTDIR=$(ls -d /usr/local/Cellar/qt/* | head -n 1)
 

--- a/profile/darwin-m1
+++ b/profile/darwin-m1
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
-alias arm="env /usr/bin/arch -arm64 /opt/homebrew/bin/bash --init-file $HOME/build-system-arm/profile/darwin-arm"
-alias intel="env /usr/bin/arch -x86_64 /usr/local/bin/bash --init-file $HOME/build-system-intel/profile/darwin-intel"
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
+
+alias arm="env /usr/bin/arch -arm64 /opt/homebrew/bin/bash --init-file $BUILD_SYSTEM_HOME/build-system-arm/profile/darwin-arm"
+alias intel="env /usr/bin/arch -x86_64 /usr/local/bin/bash --init-file $BUILD_SYSTEM_HOME/build-system-intel/profile/darwin-intel"

--- a/profile/linux-32
+++ b/profile/linux-32
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
-export VARIABLES="$HOME/build-system/variables/linux-32"
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
+export VARIABLES="$BUILD_SYSTEM_HOME/build-system/variables/linux-32"
 export COPASI_PACKAGE="Linux-32bit"
-export PATH="$HOME/build-system/bin:$PATH"
+export PATH="$BUILD_SYSTEM_HOME/build-system/bin:$PATH"

--- a/profile/linux-64
+++ b/profile/linux-64
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
-export VARIABLES="$HOME/build-system/variables/linux-64"
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
+export VARIABLES="$BUILD_SYSTEM_HOME/build-system/variables/linux-64"
 export COPASI_PACKAGE="Linux-64bit"
-export PATH="$HOME/build-system/bin:$PATH"
+export PATH="$BUILD_SYSTEM_HOME/build-system/bin:$PATH"

--- a/profile/windows
+++ b/profile/windows
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 
-export PATH="$HOME/build-system/bin:/usr/bin:/usr/local/bin:$PATH"
+if [ -z ${BUILD_SYSTEM_HOME+x} ];
+then
+    export BUILD_SYSTEM_HOME=$HOME
+fi
+export PATH="$BUILD_SYSTEM_HOME/build-system/bin:/usr/bin:/usr/local/bin:$PATH"
 PS1="[\\u@windows \\W]\\\$ "


### PR DESCRIPTION
Requiring the build system to be in `$HOME` does preclude the scripts to be used in build runners. so I need an override for this